### PR TITLE
editorconfig + clippy + PartialEq

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*.rs]
+end_of_line = lf
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/src/format.rs
+++ b/src/format.rs
@@ -11,7 +11,7 @@ pub(crate) struct Formatter<'a> {
 ///
 /// Currently we only have indentation configured, other things might be
 /// added later (such as minification).
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Style {
     indent: u32,
 }

--- a/src/query_format.rs
+++ b/src/query_format.rs
@@ -260,7 +260,7 @@ impl Displayable for Value {
             Value::Object(ref items) => {
                 f.write("{");
                 let mut first = true;
-                for (ref name, ref value) in items.iter() {
+                for (name, value) in items.iter() {
                     if first {
                         first = false;
                     } else {

--- a/src/query_grammar.rs
+++ b/src/query_grammar.rs
@@ -235,11 +235,11 @@ pub fn value<'a>(input: &mut TokenStream<'a>)
     parser(plain_value)
     .or(punct("$").with(name()).map(Value::Variable))
     .or(punct("[").with(many(parser(value))).skip(punct("]"))
-        .map(|lst| Value::List(lst)))
+        .map(Value::List))
     .or(punct("{")
         .with(many(name().skip(punct(":")).and(parser(value))))
         .skip(punct("}"))
-        .map(|lst| Value::Object(lst)))
+        .map(Value::Object))
     .parse_stream(input)
 }
 
@@ -248,11 +248,11 @@ pub fn default_value<'a>(input: &mut TokenStream<'a>)
 {
     parser(plain_value)
     .or(punct("[").with(many(parser(default_value))).skip(punct("]"))
-        .map(|lst| Value::List(lst)))
+        .map(Value::List))
     .or(punct("{")
         .with(many(name().skip(punct(":")).and(parser(default_value))))
         .skip(punct("}"))
-        .map(|map| Value::Object(map)))
+        .map(Value::Object))
     .parse_stream(input)
 }
 

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -23,7 +23,7 @@ pub struct Token<'a> {
     pub value: &'a str,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct TokenStream<'a> {
     buf: &'a str,
     position: Pos,
@@ -31,7 +31,7 @@ pub struct TokenStream<'a> {
     next_state: Option<(usize, Token<'a>, usize, Pos)>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Checkpoint {
     position: Pos,
     off: usize,
@@ -85,7 +85,7 @@ impl<'a> Resetable for TokenStream<'a> {
 // by tokenizer
 fn check_int(value: &str) -> bool {
     return value == "0" || value == "-0" ||
-       (!value.starts_with("0") && value != "-" && !value.starts_with("-0")
+       (!value.starts_with('0') && value != "-" && !value.starts_with("-0")
        && value[1..].chars().all(|x| x >= '0' && x <= '9'));
 }
 


### PR DESCRIPTION
I've done a first pass for clippy but didn't change it all in case it was clashing with your code style. The main 2 clippy lints left are:
```
108 |                 if line.trim().len() != 0 {
    |                    ^^^^^^^^^^^^^^^^^^^^^^ help: using `is_empty` is more concise: `!line.trim().is_empty()`
```
and 

```
199 |     return Ok(result);
    |     ^^^^^^^^^^^^^^^^^^ help: remove `return` as shown: `Ok(result)`
```

If you're ok with changing those, I'll do it in another commit